### PR TITLE
Disable initial setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Jenkins initialization script to disable the install setup step
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2018.5.R1]
+### Added
 - Automation scripts to build/tag the version as it's built
 - Initial plugin list
   - github-oauth:0.29
@@ -18,13 +32,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   - timestamper:1.8.9
   - versionnumber:1.9
   - workflow-multibranch:2.18
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
-- Jenkins initialization script to disable the install setup step
 
 ### Changed
 
@@ -16,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 ### Security
+
+## [2018.5.R2]
+### Added
+- Jenkins initialization script to disable the install setup step
 
 ## [2018.5.R1]
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM jenkins/jenkins:alpine
 
 ARG CONFIG_PATH=/jenkins-config
+ENV JENKINS_HOME /var/lib/jenkins
 COPY plugins.txt ${CONFIG_PATH}/plugins.txt
+COPY scripts/*.groovy $JENKINS_HOME/init.groovy.d/
 RUN /usr/local/bin/install-plugins.sh < ${CONFIG_PATH}/plugins.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkins/jenkins:alpine
 
 ARG CONFIG_PATH=/jenkins-config
-ENV JENKINS_HOME /var/lib/jenkins
+ENV JENKINS_HOME /var/jenkins_home
 COPY plugins.txt ${CONFIG_PATH}/plugins.txt
 COPY scripts/*.groovy $JENKINS_HOME/init.groovy.d/
 RUN /usr/local/bin/install-plugins.sh < ${CONFIG_PATH}/plugins.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM jenkins/jenkins:alpine
 
 ARG CONFIG_PATH=/jenkins-config
 ENV JENKINS_HOME /var/jenkins_home
+ENV JAVA_OPTS=-Djenkins.install.runSetupWizard=false
 COPY plugins.txt ${CONFIG_PATH}/plugins.txt
 COPY scripts/*.groovy $JENKINS_HOME/init.groovy.d/
 RUN /usr/local/bin/install-plugins.sh < ${CONFIG_PATH}/plugins.txt

--- a/scripts/1-DisableAdminSetup.groovy
+++ b/scripts/1-DisableAdminSetup.groovy
@@ -1,0 +1,15 @@
+#!groovy
+
+import jenkins.model.*
+import hudson.util.*;
+import jenkins.install.InstallState;
+import java.util.logging.Logger;
+
+Logger logger = Logger.getLogger("");
+
+logger.info("Disabling install setup...");
+
+def instance = Jenkins.getInstance();
+instance.setInstallState(InstallState.INITIAL_SETUP_COMPLETED);
+
+logger.info("Install setup disabled");


### PR DESCRIPTION
Fixes #3.

* Added groovy init script to mark install setup as completed.
* Updated `Dockerfile` to pass JVM args to skip the setup wizard step

@surrettcharles
