### PR TITLE
Process job DSL scripts as part of initialization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@
 Jenkinsfile
 License
 .git/
+examples/
 CHANGELOG.md
 README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Added job-dsl to plugin list
+- Added initialization script to process DSL job definitions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added job-dsl to plugin list
 - Added initialization script to process DSL job definitions
+- Added JOB_PATH environment variable to `Dockerfile`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
-## [2018.5.R3]
+## [2018.5.R2]
 ### Added
 - Added matrix-auth to plugin list
 - Added script to configure system properties
@@ -29,11 +29,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Disabled JNLP protocols
 - Enabled Agent --> Master security subsystem
 
-## [2018.5.R2]
+## [2018.5.R1]
 ### Added
 - Jenkins initialization script to disable the install setup step
 
-## [2018.5.R1]
+## [2018.5.R0]
 ### Added
 - Automation scripts to build/tag the version as it's built
 - Initial plugin list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Added job-dsl to plugin list
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkins/jenkins:alpine
 
 ENV CONFIG_PATH /jenkins-config
+ENV JOB_PATH /jenkins-jobs
 ENV JENKINS_HOME /var/jenkins_home
 ENV JAVA_OPTS=-Djenkins.install.runSetupWizard=false
 COPY plugins.txt ${CONFIG_PATH}/plugins.txt

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@ This repository contains files for generating a Docker image based on `jenkins/j
 
 When the image is started for the first time it will configure some basic Jenkins settings (security, plugins, etc.) based on configuration files supplied in a volume.
 
+## Use / Configuring Image
+This is a slightly opinionated build. Certain things will be turned on or off based on current recommended hardening (CLI, JNLP, etc.). Other things will be configurable via supplied property files.
+
+* You *must* supply the location of the configuration YAML files. By default it will expect these files in `/jenkins-config`, but this location can be overridden by supplying a value for the `CONFIG_PATH` environment variable for the container. Examples of the needed configuration files can be found in the [examples/config]() directory.
+  * The authentication mechanism configured is GitHub OAuth. OAuth is my personal preferred method, as no credentials are stored locally. At some point in the future I may investigate other OAuth provider options (gitlab, google, facebook, etc.).
+  * The authorization mechanism configured is the Jenkins matrix authorization. No real reason other than it being the one I found examples to use.
+* You may supply job definition scripts. By default the initialization script will expect these files in `/jenkins-jobs`, but this location can be overridden by supplying a value for the `JOB_PATH` environment variable for the container. If no scripts are detected, no jobs will be created. A few examples can be found in the [examples/jobs]() directory. You can see all the available options for job configuration at the [Jenkins Job DSL API site](https://jenkinsci.github.io/job-dsl-plugin/).
+
 ## Build
 The build for this image will use the latest `jenkins/jenkins:alpine` image as a base, and apply the latest version of plugins listed in `plugins.txt`.
 
 ## Versioning
-This image does not follow SemVersion versioning. Instead, the version is based on the build date and if it is built from `master` or a `feature/*` branch. The possible version formats are:
+This image does not follow traditional SemVersion versioning. Instead, the version is based on the build date and if it is built from `master` or a `feature/*` branch. The possible version formats are:
 `YYYY.MM.R#` / `latest`: Built from `master`. The number after 'R' indicates the build number for the month.
 `YYYY.MM.F#.#`: Built from a `feature/*` branch. The number after 'F' indicates which feature branch, and the number after the final '.' indicates the build number for the month.
 The reasons for this version scheme are:

--- a/examples/config/main_config.yml
+++ b/examples/config/main_config.yml
@@ -1,0 +1,21 @@
+---
+MAIN:
+    WORKSPACE_ROOT_DIR: '${JENKINS_HOME}/workspace/${ITEM_FULLNAME}-sample'
+    BUILD_RECORD_ROOT_DIR: '${ITEM_ROOTDIR}/builds-sample'
+    SYSTEM_MESSAGE: ''
+    NUMBER_OF_EXECUTORS: 2
+    LABELS:
+        - "the_master"
+        - "no_jobs_here"
+    USAGE: 'EXCLUSIVE'
+    QUIET_PERIOD: 10
+    SCM_RETRY_COUNT: 15
+    DISABLE_REMEMBER_ME: true
+GLOBAL_PROPERTIES:
+    ENVIRONMENT_VARIABLES:
+    TOOL_LOCATIONS:
+LOCATION:
+    URL: 'http://localhost:8080'
+    ADMIN_EMAIL: 'admin@localhost'
+SHELL:
+    EXECUTABLE: '/bin/sh'

--- a/examples/config/security.yml
+++ b/examples/config/security.yml
@@ -1,0 +1,59 @@
+---
+OAUTH_SETTINGS:
+    GITHUB_WEB_URI: 'https://github.com'
+    GITHUB_API_URI: 'https://api.github.com'
+    CLIENT_ID: 'your client id'
+    CLIENT_SECRET: 'your client secret'
+    SCOPES: 'read:org'
+SECURITY_GROUPS:
+    # Users with similar permission needs should be grouped
+    # into security groups. This can include GH users, teams,
+    # orgs, and the anonymous/authenticated user
+    - NAME: 'basic anonymous perms'
+      PERMISSIONS:
+        - 'hudson.model.Hudson.Read'
+      USERS:
+        - 'anonymous'
+    - NAME: 'basic users'
+      PERMISSIONS:
+        - 'hudson.model.Hudson.Read'
+        - 'hudson.model.Item.Build'
+        - 'hudson.model.Item.Cancel'
+        - 'hudson.model.View.Configure'
+        - 'hudson.model.Item.Discover'
+        - 'hudson.model.Item.Read'
+        - 'hudson.model.View.Read'
+        - 'hudson.model.View.Create'
+      USERS:
+        - 'authenticated'
+    - NAME: 'jenkins admins'
+      PERMISSIONS:
+        - 'hudson.model.Computer.Build'
+        - 'hudson.model.Computer.Configure'
+        - 'hudson.model.Computer.Connect'
+        - 'hudson.model.Computer.Create'
+        - 'hudson.model.Computer.Delete'
+        - 'hudson.model.Computer.Disconnect'
+        - 'hudson.model.Hudson.Administer'
+        - 'hudson.model.Hudson.ConfigureUpdateCenter'
+        - 'hudson.model.Hudson.Read'
+        - 'hudson.model.Hudson.RunScripts'
+        - 'hudson.model.Hudson.UploadPlugins'
+        - 'hudson.model.Item.Build'
+        - 'hudson.model.Item.Cancel'
+        - 'hudson.model.Item.Configure'
+        - 'hudson.model.Item.Create'
+        - 'hudson.model.Item.Delete'
+        - 'hudson.model.Item.Discover'
+        - 'hudson.model.Item.Read'
+        - 'hudson.model.Item.Workspace'
+        - 'hudson.model.Run.Delete'
+        - 'hudson.model.Run.Update'
+        - 'hudson.model.View.Configure'
+        - 'hudson.model.View.Create'
+        - 'hudson.model.View.Delete'
+        - 'hudson.model.View.Read'
+      USERS:
+        - 'user1'
+        - 'org*user2'
+        - 'org*team1'

--- a/examples/jobs/folders.groovy
+++ b/examples/jobs/folders.groovy
@@ -1,0 +1,8 @@
+folder('java-stuff') {
+    displayName('Java Projects')
+    description('Java based applications/services/libraries')
+}
+folder('node-stuff') {
+    displayName('Node Projects')
+    description('Node based applciations/services/modules')
+}

--- a/examples/jobs/multiBranch.groovy
+++ b/examples/jobs/multiBranch.groovy
@@ -1,0 +1,14 @@
+multibranchPipelineJob('example') {
+  branchSources {
+    github {
+      scanCredentialsId('github-ci')
+      repoOwner('owner')
+      repository('repo')
+    }
+  }
+  orphanedItemStrategy {
+    discardOldItems {
+      numToKeep(10)
+    }
+  }
+}

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,4 +1,5 @@
 github-oauth
+job-dsl
 matrix-auth
 pipeline-github
 pipeline-github-lib

--- a/scripts/9-SetupJobs.groovy
+++ b/scripts/9-SetupJobs.groovy
@@ -1,0 +1,19 @@
+import javaposse.jobdsl.plugin.JenkinsDslScriptLoader;
+import javaposse.jobdsl.plugin.JenkinsJobManagement;
+import java.util.logging.Logger;
+
+Logger logger = Logger.getLogger("");
+
+def jobDslDirectory = new File('/jenkins-jobs');
+def workspace = new File('.');
+
+def jobManagement = new JenkinsJobManagement(System.out, [:], workspace);
+
+logger.info("Loading DSL jobs...");
+
+jobDslDirectory.eachFile { jobDslScript ->
+	logger.info("Loading job ${jobDslScript.name}");
+	new JenkinsDslScriptLoader(jobManagement).runScript(jobDslScript.text);
+};
+
+logger.info("DSL jobs loaded");

--- a/scripts/9-SetupJobs.groovy
+++ b/scripts/9-SetupJobs.groovy
@@ -4,7 +4,8 @@ import java.util.logging.Logger;
 
 Logger logger = Logger.getLogger("");
 
-def jobDslDirectory = new File('/jenkins-jobs');
+String jobPath = System.getenv("JOB_PATH");
+def jobDslDirectory = new File(jobPath);
 def workspace = new File('.');
 
 def jobManagement = new JenkinsJobManagement(System.out, [:], workspace);


### PR DESCRIPTION
Fixes #7.

* Added `job-dsl` plugin
* Added script to find and process job definition files
* Added example configuration / job definition files
* Added use/configuration information to the `README.md`

@surrettcharles
